### PR TITLE
Upgrade to .NET 8 (dotnet-9 env, no inet)

### DIFF
--- a/ID3Parser_MSTest/ID3Parser_MSTest.csproj
+++ b/ID3Parser_MSTest/ID3Parser_MSTest.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ID3Parser_MSTest/ID3v23Parser_Test.cs
+++ b/ID3Parser_MSTest/ID3v23Parser_Test.cs
@@ -4,11 +4,11 @@ using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 
-namespace Id3Parser.MSTest
+namespace Id3Parser.MSTest;
+
+[TestClass]
+public class ID3v23Parser_Test
 {
-    [TestClass]
-    public class ID3v23Parser_Test
-    {
         [TestMethod]
         public void ComplexTest1()
         {
@@ -51,4 +51,3 @@ namespace Id3Parser.MSTest
             }
         }
     }
-}

--- a/ID3Parser_MSTest/ID3v2FrameHeader_Test.cs
+++ b/ID3Parser_MSTest/ID3v2FrameHeader_Test.cs
@@ -4,11 +4,11 @@ using System.Text;
 using Id3Parser.ID3v2;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Id3Parser.MSTest
+namespace Id3Parser.MSTest;
+
+[TestClass]
+public class ID3v2FrameHeader_Test
 {
-    [TestClass]
-    public class ID3v2FrameHeader_Test
-    {
         [TestMethod]
         public void ComplexTest()
         {
@@ -17,4 +17,3 @@ namespace Id3Parser.MSTest
             Assert.AreEqual("POPM", h.FrameID);
         }
     }
-}

--- a/ID3Parser_MSTest/ID3v2Header_Test.cs
+++ b/ID3Parser_MSTest/ID3v2Header_Test.cs
@@ -3,11 +3,11 @@ using Id3Parser.ID3v2;
 using System;
 using System.Reflection;
 
-namespace Id3Parser.MSTest
+namespace Id3Parser.MSTest;
+
+[TestClass]
+public class ID3v2Header_Test
 {
-    [TestClass]
-    public class ID3v2Header_Test
-    {
         [TestMethod]
         public void TestParseLength()
         {
@@ -59,4 +59,3 @@ namespace Id3Parser.MSTest
             Assert.AreEqual(3, h.Version);
         }
     }
-}

--- a/Id3Parser/ID3v2/Frame.cs
+++ b/Id3Parser/ID3v2/Frame.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Id3Parser.ID3v2
+namespace Id3Parser.ID3v2;
+
+public class Frame
 {
-    public class Frame
-    {
         public FrameHeader Header { get; protected set; }
         public ICollection<byte> RawBytes { get; protected set; }
         public string RawString { get; protected set; }
@@ -28,4 +28,3 @@ namespace Id3Parser.ID3v2
             return $"{FrameID}: {RawString}";
         }
     }
-}

--- a/Id3Parser/ID3v2/FrameHeader.cs
+++ b/Id3Parser/ID3v2/FrameHeader.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Text;
 using System.Linq;
 
-namespace Id3Parser.ID3v2
-{
+namespace Id3Parser.ID3v2;
+
     /// <summary>
     /// Заголовок фрейма IDv2 тега
     /// </summary>
@@ -74,4 +74,3 @@ namespace Id3Parser.ID3v2
             return $"{FrameID}, Length: {Length}";
         }
     }
-}

--- a/Id3Parser/ID3v2/Frames/Raw.cs
+++ b/Id3Parser/ID3v2/Frames/Raw.cs
@@ -3,13 +3,12 @@ using System.Collections.Generic;
 using System.Text;
 using System.Linq;
 
-namespace Id3Parser.ID3v2.Frames
+namespace Id3Parser.ID3v2.Frames;
+
+public class Raw : Frame
 {
-    public class Raw : Frame
-    {
         public Raw(FrameHeader header, IEnumerable<byte> valueBytes) :base(header, valueBytes.ToArray())
         {
 
         }
     }
-}

--- a/Id3Parser/ID3v2/Frames/Text.cs
+++ b/Id3Parser/ID3v2/Frames/Text.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Text;
 using System.Linq;
 
-namespace Id3Parser.ID3v2.Frames
+namespace Id3Parser.ID3v2.Frames;
+
+class TextFrame : Frame
 {
-    class TextFrame : Frame
-    {
         /// <summary>
         /// Encoded text content of frame
         /// </summary>
@@ -25,4 +25,3 @@ namespace Id3Parser.ID3v2.Frames
             return $"{FrameID}: {Value}";
         }
     }
-}

--- a/Id3Parser/ID3v2/Tag.cs
+++ b/Id3Parser/ID3v2/Tag.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Text;
 using System.Linq;
 
-namespace Id3Parser.ID3v2
+namespace Id3Parser.ID3v2;
+
+public class Tag : IMetadata
 {
-    public class Tag : IMetadata
-    {
         public TagHeader Header { get; protected set; }
         public LinkedList<Frame> Frames { get; protected set; }
 
@@ -111,4 +111,3 @@ namespace Id3Parser.ID3v2
             }
         }
     }
-}

--- a/Id3Parser/ID3v2/TagHeader.cs
+++ b/Id3Parser/ID3v2/TagHeader.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Text;
 using System.Linq;
 
-namespace Id3Parser.ID3v2
-{
+namespace Id3Parser.ID3v2;
+
     /// <summary>
     /// Заголовок ID3v2 тега
     /// </summary>
@@ -81,4 +81,3 @@ namespace Id3Parser.ID3v2
             return $"ID3v2 tag, Length: {Length}";
         }
     }
-}

--- a/Id3Parser/IMetadata.cs
+++ b/Id3Parser/IMetadata.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Id3Parser
+namespace Id3Parser;
+
+public interface IMetadata
 {
-    public interface IMetadata
-    {
         // COMM
         string? Comments { get; }
         // PCNT
@@ -43,4 +43,3 @@ namespace Id3Parser
         // TRACK
         int? TrackTotal { get; }
     }
-}

--- a/Id3Parser/Id3Parser.csproj
+++ b/Id3Parser/Id3Parser.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Nullable>Enable</Nullable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Id3Parser/V23Parser.cs
+++ b/Id3Parser/V23Parser.cs
@@ -4,10 +4,10 @@ using System.Text;
 using System.IO;
 using System.Linq;
 
-namespace Id3Parser
+namespace Id3Parser;
+
+public class V23Parser
 {
-    public class V23Parser
-    {
         public static IMetadata Parse(Stream stream)
         {
             byte[] buffer;
@@ -86,4 +86,3 @@ namespace Id3Parser
             throw new Exception("No ID3 in file");
         }
     }
-}


### PR DESCRIPTION
## Summary
- upgrade project and test project to .NET 8
- use modern MSTest package versions
- refresh all C# files to use file-scoped namespaces

## Testing
- `dotnet build Id3Parser.sln -c Release` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f9621c598832590d663c700e4b6d8